### PR TITLE
Feat: save html description in case we need it

### DIFF
--- a/Modules/config.py
+++ b/Modules/config.py
@@ -132,7 +132,7 @@ parser.add_argument(
     "-hd",
     dest="html_description",
     action="store_true",
-    help="save description in original html format",
+    help="download description as original html format, this won't work if json-description is enabled",
 )
 parser.add_argument(
     "--login",

--- a/Modules/config.py
+++ b/Modules/config.py
@@ -128,6 +128,13 @@ parser.add_argument(
     help="download description as a JSON list",
 )
 parser.add_argument(
+    "--html-description",
+    "-hd",
+    dest="html_description",
+    action="store_true",
+    help="save description in original html format",
+)
+parser.add_argument(
     "--login",
     action="store_true",
     help="extract furaffinity cookies directly from your browser",
@@ -167,6 +174,7 @@ login = args.login
 check = args.check
 index = args.index
 submissions = args.submissions
+html_description = args.html_description
 json_description = args.json_description
 metadata = args.metadata
 dont_redownload = args.redownload

--- a/Modules/download.py
+++ b/Modules/download.py
@@ -76,7 +76,10 @@ def download(path):
             idx.write(f"({view_id})\n")
 
     if config.metadata is True:
-        dsc = s.find(class_="submission-description").text.strip().replace("\r\n", "\n")
+        if config.html_description is True:
+            dsc = s.find(class_="submission-description").prettify()
+        else:
+            dsc = s.find(class_="submission-description").text.strip().replace("\r\n", "\n")
         if config.json_description is True:
             dsc = []
         data = {

--- a/Modules/functions.py
+++ b/Modules/functions.py
@@ -145,8 +145,10 @@ def next_button(page_url):
     else:
         parse_next_button = s.find("a", class_="button standard right", text="Next")
         page_num = fav_next_button(parse_next_button)
+    next_page_url = (parse_next_button.parent.attrs['action'] if 'action'
+                    in parse_next_button.parent.attrs else parse_next_button.attrs['href'])
     print(
-        f"Downloading page {page_num} - {config.BASE_URL}{parse_next_button.parent.attrs['action']}"
+        f"Downloading page {page_num} - {config.BASE_URL}{next_page_url}"
     )
     return page_num
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ options:
   --filter              enable submission filter
   --metadata, -m        enable metadata saving
   --download DOWNLOAD   download a specific submission by providing its id
+  --html-description, -hd
+                        download description as original html format, this won't work if json-description is enabled
   --json-description, -jd
                         download description as a JSON list
   --login               extract furaffinity cookies directly from your browser


### PR DESCRIPTION
Hi,
Add a new option to save original html of descripton in case we want to save format. This especially usful when we download illustration with novel attached in description with format.
